### PR TITLE
Added option.linkUrl to link decorator.

### DIFF
--- a/src/editor/index.jsx
+++ b/src/editor/index.jsx
@@ -257,7 +257,7 @@ class MdEditor extends React.Component {
       })
     } else if (type === 'link') {
       decoratedText = decorate.getDecoratedText(type, {
-        linkUrl: this.config.linkUrl
+        linkUrl: option.linkUrl || this.config.linkUrl
       })
     } else {
       decoratedText = decorate.getDecoratedText(type, option)


### PR DESCRIPTION
Before change only config.linkUrl could be passed in link decorator. Now it's possible to pass linkUrl as an option when calling handleDecorate.
Example:
`handleDecorate('link', { target: 'name', linkUrl: assetUrl })`

Could you please review and merge if you agree on the change?