### PR TITLE
Add build config to split styling & code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-markdown-editor-lite",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4773,6 +4773,12 @@
         "path-is-inside": "^1.0.2"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npm.taobao.org/is-plain-object/download/is-plain-object-2.0.4.tgz",
@@ -5725,6 +5731,18 @@
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true
     },
+    "mini-css-extract-plugin": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
+      "integrity": "sha512-MNpRGbNA52q6U92i0qbVpQNsgk7LExy41MdAlG84FeytfDOtRIf/mCHdEgG8rpTKOaNKiqUnZdlptF469hxqOw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npm.taobao.org/minimalistic-assert/download/minimalistic-assert-1.0.1.tgz",
@@ -5915,6 +5933,13 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "http://registry.npm.taobao.org/nanomatch/download/nanomatch-1.2.13.tgz",
@@ -6074,6 +6099,18 @@
       "resolved": "http://registry.npm.taobao.org/normalize-range/download/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -6788,6 +6825,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
     "pretty-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npm.taobao.org/pretty-error/download/pretty-error-2.1.1.tgz",
@@ -6936,6 +6979,16 @@
       "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1569207136481&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
       "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
       "dev": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -7967,6 +8020,15 @@
         }
       }
     },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npm.taobao.org/source-list-map/download/source-list-map-2.0.1.tgz",
@@ -8219,6 +8281,12 @@
           }
         }
       }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
     },
     "string-width": {
       "version": "3.1.0",
@@ -9064,6 +9132,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "^0.12.0"
           },
           "dependencies": {
@@ -9926,6 +9995,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "nan": "^2.12.1",
             "node-pre-gyp": "^0.12.0"
           },
           "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "start": "webpack --config webpack.config.js",
     "dev": "webpack-dev-server  --host 0.0.0.0 --open http://localhost:8080",
     "prod": "webpack --config webpack.prod.config.js",
+    "nostyle": "webpack --config webpack.prod.nostyle.config.js",
+    "release": "npm run prod && npm run nostyle",
     "dev-build": "webpack --config webpack.dev-build.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -72,6 +74,7 @@
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
     "markdown-it-task-lists": "^2.1.1",
+    "mini-css-extract-plugin": "^0.8.0",
     "mocha": "^5.2.0",
     "postcss-loader": "^2.1.6",
     "react": "^16.8.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,6 @@ const config = {
     extensions: ['.js', '.jsx'],
   },
   plugins: [
-    // new CleanWebpackPlugin(['dist']),    
     new HtmlWebpackPlugin({
       template: path.join(__dirname, './public/index.html'),
       filename: 'index.html',

--- a/webpack.prod.nostyle.config.js
+++ b/webpack.prod.nostyle.config.js
@@ -1,7 +1,8 @@
 const path = require('path');
 // const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const webpack = require('webpack');
 const version = require("./package.json").version;
 const banner =
@@ -12,7 +13,7 @@ const banner =
   " */\n";
 const config = {
   entry: {
-    index: './src/index',
+    "index.nostyle": './src/index'
   },
   output: {
     filename: '[name].js',
@@ -45,6 +46,9 @@ const config = {
         use: [
           'style-loader',
           {
+            loader: MiniCssExtractPlugin.loader,
+          },
+          {
             loader: 'css-loader',
             options: {
               importLoaders: 1
@@ -69,14 +73,13 @@ const config = {
     extensions: ['.js', '.jsx'],
   },
   plugins: [
-    new CleanWebpackPlugin(['lib']),
     new webpack.BannerPlugin({
       banner,
       raw: false
     }),
-    new CopyWebpackPlugin([{
-      from: 'src/index.d.ts'
-    }])
+    new MiniCssExtractPlugin({
+      filename: 'index.css',
+    })
   ],
 };
 


### PR DESCRIPTION
For a React project I am trying to use this component, but don't want the component to inject styling into my `<head>` of the page, as I need to be able to overwrite the styling.

I added an extra Webpack config: This will do the same as `prod`, but will save the styling in `lib/index.css` and the bare component in `lib/index.nostyle.js`.

Build step is added in `package.json` (and combined in the `release` task)