### PR TITLE
bugfix _isKeyMatch Function

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -527,11 +527,12 @@ class Editor extends React.Component<EditorProps, any> {
           return false;
         }
       }
-    }
-    if (event.key) {
-      return event.key === key;
     } else {
-      return event.keyCode === keyCode;
+      if (event.key) {
+        return event.key === key;
+      } else {
+        return event.keyCode === keyCode;
+      }
     }
   }
 


### PR DESCRIPTION
Bug occurred in package "v0.6.0" after upgrading from "v0.5.2"

I thought, "The value of the key pressed is entered."
But when I press the "y" or "z" key, "Nothing happens"

Fixed a bug in this PR.

my environments


```
$ uname -a
Darwin xxx.local 19.2.0 Darwin Kernel Version 19.2.0: Sat Nov  9 03:47:04 PST 2019; root:xnu-6153.61.1~20/RELEASE_X86_64 x86_64
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.15.2
BuildVersion:   19C57
```


please review!