### PR TITLE
Fix header insertion

### DIFF
--- a/src/plugins/header/index.tsx
+++ b/src/plugins/header/index.tsx
@@ -44,7 +44,7 @@ export default class Header extends PluginComponent<State> {
       >
         <Icon type="font-size" />
         <DropList show={this.state.show} onClose={this.hide}>
-          <HeaderList onSelectHeader={(header: string) => this.editor.insertMarkdown(header)} />}
+          <HeaderList onSelectHeader={(header: string) => this.editor.insertMarkdown(header)} />
         </DropList>
       </span>
     );

--- a/src/utils/decorate.ts
+++ b/src/utils/decorate.ts
@@ -19,7 +19,7 @@ const SIMPLE_DECORATOR: { [x: string]: [string, string] } = {
   code: ['\n```\n', '\n```\n'],
 };
 // 插入H1-H6
-for (let i = 1; i < 6; i++) {
+for (let i = 1; i <= 6; i++) {
   SIMPLE_DECORATOR[`h${i}`] = [`\n${repeat('#', i)} `, '\n'];
 }
 


### PR DESCRIPTION
As you can see on the official demo, there's a curly brace in the header list:
![image](https://user-images.githubusercontent.com/17034772/74470808-7a7cfe80-4e9f-11ea-84ae-243a42d5c686.png)

This fixes that, as well as `h6` insertion.