### PR TITLE
Add a configuration option to disable the default preview styles

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -11,6 +11,7 @@
 | config.view | 配置哪些项目默认被显示，包括：menu（菜单栏），md（编辑器)，html（预览区） | Object | `{ menu: true, md: true, html: true }` |  |
 | config.canView | 配置哪些项目可以被显示，包括：menu（菜单栏），md（编辑器)，html（预览区），fullScreen（全屏），hideMenu（隐藏菜单按钮） | Object | `{ menu: true, md: true, html: true, fullScreen: true, hideMenu: true }` |  |
 | config.htmlClass | 预览区域的className | String | `''` |  |
+| config.applyDefaultHtmlStyle | ? | Boolean | `true` |  |
 | config.markdownClass | 编辑区域的className | String | `''` |  |
 | config.imageUrl | 当没有定义上传函数时，默认插入的图片 | String | `''` |  |
 | config.linkUrl | 默认插入的链接日志 | String | `''` |  |
@@ -87,6 +88,7 @@ export default (props) => {
 | config.view | Controls which items will be displayd by default, includes: menu(Menu bar), md(Editor), html(Preview) | Object | `{ menu: true, md: true, html: true }` |  |
 | config.canView | Controls which items can be displayd, includes: menu(Menu bar), md(Editor), html(Preview), fullScreen(Full screen)，hideMenu(Hide button to toggle menu bar) | Object | `{ menu: true, md: true, html: true, fullScreen: true, hideMenu: true }` |  |
 | config.htmlClass | className of preview pane | String | `''` |  |
+| config.applyDefaultHtmlStyle | Whether to apply a set of default styles in the preview pane | Boolean | `true` |  |
 | config.markdownClass | className of editorpane | String | `''` |  |
 | config.imageUrl | default image url | String | `''` |  |
 | config.linkUrl | default link url | String | `''` |  |

--- a/src/demo/index.tsx
+++ b/src/demo/index.tsx
@@ -136,8 +136,8 @@ class Demo extends React.Component {
               },
               imageUrl: 'https://octodex.github.com/images/minion.png'
             }}
-            onChange={this.handleEditorChange} 
-          />  
+            onChange={this.handleEditorChange}
+          />
         </div> */}
       </div>
     );

--- a/src/editor/defaultConfig.ts
+++ b/src/editor/defaultConfig.ts
@@ -15,6 +15,7 @@ const defaultConfig: EditorConfig = {
     hideMenu: true,
   },
   htmlClass: '',
+  applyDefaultHtmlStyle: true,
   markdownClass: '',
   syncScrollMode: ['rightFollowLeft', 'leftFollowRight'],
   imageUrl: '',

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -604,6 +604,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
               <HtmlRender
                 html={this.state.html}
                 className={this.config.htmlClass}
+                applyDefaultHtmlStyle={this.config.applyDefaultHtmlStyle}
                 ref={(instance: HtmlRender) => (this.nodeMdPreview = instance)}
               />
             </div>

--- a/src/editor/preview.tsx
+++ b/src/editor/preview.tsx
@@ -5,6 +5,7 @@ export type HtmlType = string | React.ReactElement;
 export interface PreviewProps {
   html: HtmlType;
   className?: string;
+  applyDefaultHtmlStyle?: boolean;
 }
 
 export abstract class Preview<T extends HTMLElement> extends React.Component<PreviewProps, any> {
@@ -31,17 +32,20 @@ export class HtmlRender extends Preview<HTMLDivElement> {
     }
   }
   render() {
+    const customHtmlStyle = this.props.applyDefaultHtmlStyle === undefined || this.props.applyDefaultHtmlStyle;
+    const className = [customHtmlStyle ? 'custom-html-style' : '', this.props.className || ''].join(' ');
+
     return typeof this.props.html === 'string'
       ? React.createElement('div', {
           ref: this.el,
           dangerouslySetInnerHTML: { __html: this.props.html },
-          className: `custom-html-style ${this.props.className || ''}`,
+          className,
         })
       : React.createElement(
           'div',
           {
             ref: this.el,
-            className: `custom-html-style ${this.props.className || ''}`,
+            className,
           },
           this.props.html,
         );

--- a/src/share/var.ts
+++ b/src/share/var.ts
@@ -20,6 +20,7 @@ export interface EditorConfig {
     hideMenu: boolean;
   };
   htmlClass?: string;
+  applyDefaultHtmlStyle?: boolean;
   markdownClass?: string;
   imageUrl?: string;
   imageAccept?: string;


### PR DESCRIPTION
Adds a new configuration option `applyDefaultHtmlStyle` enabling the users to opt-out the default styles defined for the preview pain.

Motivation:
As the HTML rendering is provided by the user, it's very likely that the output already has the intended styling (e.g. if there's a common renderer used across the whole application). In those cases it makes sense for the preview to match exactly how the content will be rendered in other places on the website, so disabling the default styles is necessary.