### PR TITLE
Fix table plugin insert

### DIFF
--- a/src/utils/decorate.ts
+++ b/src/utils/decorate.ts
@@ -25,19 +25,11 @@ for (let i = 1; i < 6; i++) {
 
 function decorateTableText(option: any) {
   const { row = 2, col = 2 } = option;
-  const rowHeader = ['|'];
-  const rowData = ['|'];
-  const rowDivision = ['|'];
-  let colStr = '';
-  for (let i = 1; i < col; i++) {
-    rowHeader.push(' Head |');
-    rowDivision.push(' --- |');
-    rowData.push(' Data |');
-  }
-  for (let j = 0; j <= row; j++) {
-    colStr += '\n' + rowData.join('');
-  }
-  return `\n${rowHeader.join('')}\n${rowDivision.join('')}${colStr}\n`;
+  const headerLine = '|' + ' Head |'.repeat(col);
+  const dividerLine = '|' + ' --- |'.repeat(col);
+  const rowLine = '|' + ' Data |'.repeat(col);
+  const body = (rowLine + '\n').repeat(row - 1);
+  return '\n' + [headerLine, dividerLine, body].join('\n');
 }
 
 function decorateList(type: 'order' | 'unordered', target: string) {

--- a/test/utils/decorate.spec.ts
+++ b/test/utils/decorate.spec.ts
@@ -61,8 +61,8 @@ describe('Test getDecorated', function() {
   // 表格
   it('Table', function() {
     expect(getDecorated('', 'table', {
-      row: 2,
-      col: 3
+      row: 4,
+      col: 2
     })).to.deep.equal({
       text: "\n| Head | Head |\n| --- | --- |\n| Data | Data |\n| Data | Data |\n| Data | Data |\n"
     });


### PR DESCRIPTION
The current insert behavior is clearly wrong, that's what you get when selecting 2x2 grid:

![image](https://user-images.githubusercontent.com/17034772/74485778-cf2e7280-4ebb-11ea-8187-6376bc0a0da9.png)

There's even a test asserting the incorrect behavior ^^

It's debatable whether the header row counts into the grid or not, but looking at some random editors, it rather does. So for 2x2 grid the results should be:

![image](https://user-images.githubusercontent.com/17034772/74485994-51b73200-4ebc-11ea-99fd-2ef5cfa1cf98.png)
