### PR TITLE
Fix logger

### DIFF
--- a/src/plugins/logger/logger.ts
+++ b/src/plugins/logger/logger.ts
@@ -31,17 +31,11 @@ class Logger {
     if (!this.hasUndo()) {
       return undefined;
     }
-    // 最顶上的一个是当前状态，所以要pop两次才能得到之前的结果
     const current = this.record.pop();
-    const last = this.record.pop();
-    if (typeof last !== 'undefined' && this.record.length === 0) {
-      // 如果只剩了初始化值，还是把它给放回去，不然之后就没用的了
-      this.record.push(last);
-    }
-    if (typeof current !== 'undefined') {
+    if (current !== undefined) {
       this.recycle.push(current);
     }
-    return last;
+    return this.getLast();
   }
 
   redo() {

--- a/test/plugins/logger.spec.ts
+++ b/test/plugins/logger.spec.ts
@@ -1,0 +1,20 @@
+import Logger from '../../src/plugins/logger/logger';
+import { expect } from 'chai';
+
+describe("Logger", function() {
+  describe("undo", function() {
+    it("returns undefined if there is no previous value", function() {
+      const logger = new Logger();
+      expect(logger.undo()).to.be.undefined;
+    });
+
+    it("returns the previous value if there is one", function() {
+      const logger = new Logger();
+      logger.push('S');
+      logger.push('Sh');
+      logger.push('She');
+      expect(logger.undo()).to.equal('Sh');
+      expect(logger.undo()).to.equal('S');
+    });
+  });
+});


### PR DESCRIPTION
Currently when you click `undo` multiple times, it takes you back 2 steps instead of 1. That's because the code remove both current and previous value from the logger `record`. The correct approach is to take the current value, move it to the `recycle` list and return whatever is at the end of `record` (the new current value) without removing it.