### PR TITLE
List React as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "mochawesome": "^4.1.0",
     "nyc": "^15.0.0",
     "prettier": "^1.19.1",
+    "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-markdown": "^4.3.1",
     "source-map-support": "^0.5.16",
@@ -81,7 +82,7 @@
     "url-loader": "^2.1.0",
     "uuid": "^3.4.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "react": "^16.9.0"
   },
   "lint-staged": {


### PR DESCRIPTION
I was having trouble when trying to use this library together with an experimental build of react.
My dependency on react did not resolve to the same version as that of react-markdown-editor-lite, so this resulted in having two different versions of react, which is wrong. Excerpt from my yarn.lock:
```
react@^0.0.0-experimental-e5d06e34b:
  version "0.0.0-experimental-e5d06e34b"
  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-e5d06e34b.tgz#bfdbe2b228e1d1967330fc18b9e05331818f610d"
  integrity sha512-2WUOtH5VE3cSyg22XxavfDoMQDIc51Pyudr/mrU1I1GcWIDKVg7QA/1dh5DlKyIvyWlM44pkwqz7V7gYHFzf2A==
  dependencies:
    loose-envify "^1.1.0"
    object-assign "^4.1.1"

react@^16.9.0:
  version "16.13.1"
  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
  dependencies:
    loose-envify "^1.1.0"
    object-assign "^4.1.1"
    prop-types "^15.6.2"
```

Forking the library and specifying react as a peerDependency instead seems to have fixed my issue.