### PR TITLE
Add the id attribute in props

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -15,13 +15,12 @@ import { HtmlRender, HtmlType } from './preview';
 
 type Plugin = { comp: any; config: any };
 
-interface EditorProps extends EditorConfig {
-  value?: string;
+type EditorProps = Pick<
+  JSX.IntrinsicElements['textarea'],
+  'id' | 'name' | 'readOnly' | 'style' | 'placeholder' | 'required'
+> & {
   renderHTML: (text: string) => HtmlType | Promise<HtmlType> | (() => HtmlType);
-  style?: React.CSSProperties;
-  placeholder?: string;
-  readOnly?: boolean;
-  config?: any;
+  config?: EditorConfig;
   plugins?: string[];
   // Configs
   onChange?: (
@@ -31,7 +30,8 @@ interface EditorProps extends EditorConfig {
     },
     event?: React.ChangeEvent<HTMLTextAreaElement>,
   ) => void;
-}
+  value?: string;
+};
 
 interface EditorState {
   text: string;
@@ -638,7 +638,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
           )}
           <section className={`section sec-md ${view.md ? 'visible' : 'in-visible'}`}>
             <textarea
-              id="textarea"
+              id={this.props.id || 'textarea'}
               ref={this.nodeMdText}
               name={this.props.name || 'textarea'}
               placeholder={this.props.placeholder}
@@ -646,6 +646,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
               value={this.state.text}
               className={`section-container input ${this.config.markdownClass || ''}`}
               wrap="hard"
+              required={this.props.required}
               onChange={this.handleChange}
               onScroll={this.handleInputScroll}
               onMouseOver={() => (this.shouldSyncScroll = 'input')}


### PR DESCRIPTION
Added **id** and **required** attributes to props in order to make the underlying textarea a little more compliant with HTML5 requirements.

Also, props type have been adjusted to reuse JSX and React ones. The `value` one is an exception because we don't handle the same types as the native textarea.