### PR TITLE
Adding default text to be rendered in the preview on component mount

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -144,7 +144,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
   }
 
   componentDidMount() {
-    this.renderHTML(this.props.value || '');
+    this.renderHTML(this.props.value || this.props.defaultValue || '');
     emitter.on(emitter.EVENT_LANG_CHANGE, this.handleLocaleUpdate);
     // init i18n
     i18n.setUp();

--- a/test/editor.spec.tsx
+++ b/test/editor.spec.tsx
@@ -37,5 +37,15 @@ describe('Test Editor', function() {
     }
   });
 
+  // render with default value produces a preview
+  it('render with default value', function() {
+    const text = "Hello World!";
+    const { getByText } = render(<Editor id="myeditor" renderHTML={text => text} defaultValue={text} />);
+    
+    // Attempt to fetch the preview pane by using the CSS selector
+    const element = getByText(text, { selector: ".custom-html-style"});
+    expect(element.innerHTML).to.equals(text);
+  });
+
   afterEach(cleanup);
 });


### PR DESCRIPTION
1. Simple change similar to the editor value that reads from the `value || defaultValue || ''` not sure why the preview should be any different.

1. Added unit tests asserting that the preview is now being shown.