### PR TITLE
Feature/nextjs custom plugins docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ export default function() {
 }
 ```
 
+Full example see [here](https://codesandbox.io/s/next-js-80bne)
+
 ## Import in Browser
 Since 1.1.0, You can add `script` and `link` tags in your browser and use the global variable `ReactMarkdownEditorLite`. 
 
@@ -133,6 +135,7 @@ externals: {
 * [With unform](https://codesandbox.io/s/rmel-demo-with-unform-qx34y)
 * [Write a plugin](https://codesandbox.io/s/rmel-demo-write-plugin-p82fc)
 * [Replace default icons](https://codesandbox.io/s/rmel-demo-replace-icon-pl1n3)
+* [In Next.js](https://codesandbox.io/s/next-js-80bne)
 
 ## Authors
 - ShuangYa [github/sylingd](https://github.com/sylingd)

--- a/README_CN.md
+++ b/README_CN.md
@@ -113,6 +113,8 @@ export default function() {
 }
 ```
 
+完整示例[见此](https://codesandbox.io/s/next-js-80bne)
+
 ## 浏览器引入
 自1.1.0起，你可以在浏览器中使用`script`和`link`标签直接引入文件，并使用全局变量`ReactMarkdownEditorLite`。
 
@@ -133,6 +135,7 @@ externals: {
 * [在unform中使用](https://codesandbox.io/s/rmel-demo-with-unform-qx34y)
 * [编写插件](https://codesandbox.io/s/rmel-demo-write-plugin-p82fc)
 * [替换默认图标](https://codesandbox.io/s/rmel-demo-replace-icon-pl1n3)
+* [在Next.js中使用](https://codesandbox.io/s/next-js-80bne)
 
 ## 主要作者
 - ShuangYa [github/sylingd](https://github.com/sylingd)

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -119,8 +119,9 @@ const MdEditor = dynamic(
 ```
 
 ## Written a plugin
-### Demo
-[View online](https://codesandbox.io/s/rmel-demo-write-plugin-p82fc)
+### Demos
+* [Demo](https://codesandbox.io/s/rmel-demo-write-plugin-p82fc)
+* [SSR Demo](https://codesandbox.io/s/next-js-80bne)
 ### Normal
 Plugin is a React Component, and must extend PluginComponent.
 

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -94,6 +94,30 @@ Editor.unuse(Plugins.Header);
 const plugins = ['header', 'table', 'my-plugins', 'link', 'clear', 'logger', 'mode-toggle', 'full-screen'];
 <Editor plugins={plugins} />
 ```
+## Demo for NextJS with custom plugin
+```js
+import dynamic from "next/dynamic";
+import ReactMarkdown from "react-markdown";
+import "react-markdown-editor-lite/lib/index.css";
+
+const MdEditor = dynamic(
+  () => {
+    return new Promise((resolve) => {
+      Promise.all([
+        import("react-markdown-editor-lite"),
+        import("./plugin")
+      ]).then((res) => {
+        res[0].default.use(res[1].default);
+        resolve(res[0].default);
+      });
+    });
+  },
+  {
+    ssr: false
+  }
+);
+```
+
 ## Written a plugin
 ### Demo
 [View online](https://codesandbox.io/s/rmel-demo-write-plugin-p82fc)

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -94,29 +94,6 @@ Editor.unuse(Plugins.Header);
 const plugins = ['header', 'table', 'my-plugins', 'link', 'clear', 'logger', 'mode-toggle', 'full-screen'];
 <Editor plugins={plugins} />
 ```
-## Demo for NextJS with custom plugin
-```js
-import dynamic from "next/dynamic";
-import ReactMarkdown from "react-markdown";
-import "react-markdown-editor-lite/lib/index.css";
-
-const MdEditor = dynamic(
-  () => {
-    return new Promise((resolve) => {
-      Promise.all([
-        import("react-markdown-editor-lite"),
-        import("./plugin")
-      ]).then((res) => {
-        res[0].default.use(res[1].default);
-        resolve(res[0].default);
-      });
-    });
-  },
-  {
-    ssr: false
-  }
-);
-```
 
 ## Written a plugin
 ### Demos

--- a/docs/plugin.zh-CN.md
+++ b/docs/plugin.zh-CN.md
@@ -94,6 +94,29 @@ Editor.unuse(Plugins.Header);
 const plugins = ['header', 'table', 'my-plugins', 'link', 'clear', 'logger', 'mode-toggle', 'full-screen'];
 <Editor plugins={plugins} />
 ```
+## 带自定义插件的NextJS Demo
+```js
+import dynamic from "next/dynamic";
+import ReactMarkdown from "react-markdown";
+import "react-markdown-editor-lite/lib/index.css";
+
+const MdEditor = dynamic(
+  () => {
+    return new Promise((resolve) => {
+      Promise.all([
+        import("react-markdown-editor-lite"),
+        import("./plugin")
+      ]).then((res) => {
+        res[0].default.use(res[1].default);
+        resolve(res[0].default);
+      });
+    });
+  },
+  {
+    ssr: false
+  }
+);
+```
 ## 编写插件
 ### Demo
 [在线查看](https://codesandbox.io/s/rmel-demo-write-plugin-p82fc)


### PR DESCRIPTION
Updated docs on how to include react-markdown-editor-lite with SSR frameworks such as NextJS