### PR TITLE
Ignore key-down enter during character conversion

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -43,6 +43,7 @@ interface EditorState {
   text: string;
   html: HtmlType;
   fullScreen: boolean;
+  composing: boolean;
   plugins: { [x: string]: React.ReactElement[] };
   view: {
     menu: boolean;
@@ -127,6 +128,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
       html: '',
       view: this.config.view || defaultConfig.view!,
       fullScreen: false,
+      composing: false,
       plugins: this.getPlugins(),
     };
 
@@ -379,7 +381,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
 
   private handleEditorKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     const { keyCode, key, currentTarget } = e;
-    if (keyCode === 13 || key === 'Enter') {
+    if ((keyCode === 13 || key === 'Enter') && this.state.composing === false) {
       const text = e.currentTarget.value;
       const curPos = currentTarget.selectionStart;
       const lineInfo = getLineAndCol(text, curPos);
@@ -846,6 +848,8 @@ class Editor extends React.Component<EditorProps, EditorState> {
               onScroll={this.handleInputScroll}
               onMouseOver={() => (this.shouldSyncScroll = 'md')}
               onKeyDown={this.handleEditorKeyDown}
+              onCompositionStart={() => this.setState({ composing: true })}
+              onCompositionEnd={() => this.setState({ composing: false })}
               onPaste={this.handlePaste}
               onFocus={this.handleFocus}
               onBlur={this.handleBlur}

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -43,7 +43,6 @@ interface EditorState {
   text: string;
   html: HtmlType;
   fullScreen: boolean;
-  composing: boolean;
   plugins: { [x: string]: React.ReactElement[] };
   view: {
     menu: boolean;
@@ -113,6 +112,8 @@ class Editor extends React.Component<EditorProps, EditorState> {
 
   private hasContentChanged = true;
 
+  private composing = false;
+
   private handleInputScroll: (e: React.UIEvent<HTMLTextAreaElement>) => void;
 
   private handlePreviewScroll: (e: React.UIEvent<HTMLDivElement>) => void;
@@ -128,7 +129,6 @@ class Editor extends React.Component<EditorProps, EditorState> {
       html: '',
       view: this.config.view || defaultConfig.view!,
       fullScreen: false,
-      composing: false,
       plugins: this.getPlugins(),
     };
 
@@ -381,7 +381,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
 
   private handleEditorKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     const { keyCode, key, currentTarget } = e;
-    if ((keyCode === 13 || key === 'Enter') && this.state.composing === false) {
+    if ((keyCode === 13 || key === 'Enter') && this.composing === false) {
       const text = e.currentTarget.value;
       const curPos = currentTarget.selectionStart;
       const lineInfo = getLineAndCol(text, curPos);
@@ -848,8 +848,8 @@ class Editor extends React.Component<EditorProps, EditorState> {
               onScroll={this.handleInputScroll}
               onMouseOver={() => (this.shouldSyncScroll = 'md')}
               onKeyDown={this.handleEditorKeyDown}
-              onCompositionStart={() => this.setState({ composing: true })}
-              onCompositionEnd={() => this.setState({ composing: false })}
+              onCompositionStart={() => this.composing = true}
+              onCompositionEnd={() => this.composing = false}
               onPaste={this.handlePaste}
               onFocus={this.handleFocus}
               onBlur={this.handleBlur}


### PR DESCRIPTION
Hi there
Thank you very much for providing this simple and easy to use markdown editor!

I had a problem that when using it in Japanese, the key-down enter to determine character conversion was misinterpreted as a normal line break.
I have tried to fix this problem and would appreciate it if you could review it!

#### Before
![ezgif-3-8c88dcb2d3d0](https://user-images.githubusercontent.com/81555622/143978804-aa09282b-9f1e-445d-9a14-b5f7128ea39d.gif)


#### After
![ezgif-3-7fcadd9bd768](https://user-images.githubusercontent.com/81555622/143978817-1688182c-845e-44bb-82d7-5e21d3a0d7b6.gif)
