### PR TITLE
Add react 18 as peer dependency to 16.9 and 17.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "url-loader": "^2.1.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0 || ^17.0.0"
+    "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
   },
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [


### PR DESCRIPTION
Hello, I hope this will remove the conflict when I try to use the editor with React 18. Thank you!