### PR TITLE
Allow url-list content type when pasting

### DIFF
--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -841,7 +841,7 @@ class Editor extends React.Component<EditorProps, EditorState> {
             });
           });
         }
-      } else if (it.kind === 'string' && it.type === 'text/plain') {
+      } else if (it.kind === 'string' && (it.type === 'text/plain' || it.type === 'text/uri-list')) {
         queue.push(new Promise((resolve) => it.getAsString(resolve)));
       }
     });


### PR DESCRIPTION
On mobile Safari, when you Share, Copy... you get a type of uri-list. This fix will allow that type to be pasted as regular text.